### PR TITLE
Add Hacobu, Inc

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ List of companies offering GitHub Copilot to all engineers
 * [FreakOut, フリークアウト](https://www.fout.co.jp/)
 * [Gaudiy](https://gaudiy.com/)
 * [GIG](https://giginc.co.jp/)
+* [Hacobu](https://hacobu.jp/)
 * [High Link](https://high-link.co.jp/)
 * [Ikyu, 一休](https://www.ikyu.co.jp/)
 * [KAI-YOU](https://kai-you.net/)


### PR DESCRIPTION
News : 
Hacobu、「ChatGPT」と「GitHub Copilot for Business」を導入！会社丸ごと「生産性向上」プロジェクトを始動

https://movo.co.jp/news/3339